### PR TITLE
新增destroy方法，页面销毁时调用destroy可避免动画二次渲染时失效的问题

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
-import {setup, g} from './adapter'
-const {window, document, navigator} = g
+import { setup, g } from './adapter'
+const { window, document, navigator } = g
 
-;'__LOTTIE_CANVAS__'
+  ; '__LOTTIE_CANVAS__'
 
-function loadAnimation(options) {
+function loadAnimation (options) {
   ['wrapper', 'container'].forEach(key => {
     if (key in options) {
       throw new Error(`Not support '${key}' parameter in miniprogram version of lottie.`)
@@ -20,11 +20,25 @@ function loadAnimation(options) {
   return window.lottie.loadAnimation(options)
 }
 
-const {freeze, unfreeze} = window.lottie
+const miniprogramDestroy = window.lottie.destroy
+
+const { freeze, unfreeze, getRegisteredAnimations } = window.lottie
+
+function destroy (name) {
+  const animations = getRegisteredAnimations() || []
+  animations.forEach(animation => {
+    animation.wrapper = {
+      innerHTML: ''
+    }
+  })
+  miniprogramDestroy(name)
+}
+
 
 export {
   setup,
   loadAnimation,
   freeze,
   unfreeze,
+  destroy
 }


### PR DESCRIPTION
最近社区对这类问题讨论蛮多的，好像都是二次渲染的问题，加个销毁方法就行了