### PR TITLE
chore(deps): 更新 lottie-web 库版本为最新 5.7.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "string-replace-loader": "^2.2.0",
     "webpack": "^4.39.1",
     "webpack-cli": "^3.3.6",
-    "lottie-web": "5.5.7",
+    "lottie-web": "^5.7.4",
     "copy-webpack-plugin": "^6.0.3"
   }
 }


### PR DESCRIPTION
lottie-web 库 相差两个次版本， 所以更新了一下依赖库版本